### PR TITLE
Feature/SIE-103 redesign image stimuli observer

### DIFF
--- a/src/firebase/api/gcp-utils.js
+++ b/src/firebase/api/gcp-utils.js
@@ -55,7 +55,7 @@ const uploadImageToStorage = async (
 export const observeStimuliCompletion =
   async (userId, experimentId, imageUrlsHandler, errorHandler) => {
     // TODO: refactor for multiple experiments inside user doc
-    const subscribe = firestore.collection(firestoreCollections.USER)
+    firestore.collection(firestoreCollections.USER)
       .doc(userId).onSnapshot(async (doc) => {
         const userDoc = doc.data();
         const stimuliStatus = userDoc.sie_stimuli_generation_status;
@@ -78,9 +78,6 @@ export const observeStimuliCompletion =
           errorHandler(stimuliStatus);
         }
       });
-    setTimeout(() => {
-      subscribe();
-    }, 4000);
   };
 
 

--- a/src/firebase/api/gcp-utils.js
+++ b/src/firebase/api/gcp-utils.js
@@ -80,16 +80,6 @@ export const observeStimuliCompletion =
       });
   };
 
-
-/**
- * Detach the listener to the user doc, stop listening to changes.
- */
-export const unsubscribe = firestore.collection(firestoreCollections.USER)
-  .onSnapshot(() => {
-    return;
-  });
-
-
 /**
  * Get all stimuli image urls from bucket to display in img tags.
  * @param {String} userId user id

--- a/src/firebase/api/gcp-utils.js
+++ b/src/firebase/api/gcp-utils.js
@@ -55,14 +55,11 @@ const uploadImageToStorage = async (
 export const observeStimuliCompletion =
  async (userId, experimentId, imageUrlsHandler, errorHandler) => {
    // TODO: refactor for multiple experiments inside user doc
-   console.log('listening...');
    firestore.collection(firestoreCollections.USER).doc(userId)
      .onSnapshot((doc) => {
        const userDoc = doc.data();
-       console.log(userDoc);
        const stimuliStatus = userDoc.sie_stimuli_generation_status;
        if (stimuliStatus === 'completed') {
-         console.log(userDoc);
          // call getFileUrlsFromBucket once ready to display stimuli
          getFileUrlsFromBucket(userId, experimentId).then((results) => {
            const status = results.status;

--- a/src/firebase/api/gcp-utils.js
+++ b/src/firebase/api/gcp-utils.js
@@ -63,11 +63,9 @@ export const observeStimuliCompletion =
         // call getFileUrlsFromBucket once ready to display stimuli
           await getSieStimuliFromBucket(userId, experimentId)
             .then((results) => {
-              console.log(results);
               const status = results.status;
               if (status === StatusCodes.OK) {
               // successfully get all image urls
-                // return results;
                 imageUrlsHandler(results.data);
               } else {
               // one of the image url is unable to fetch
@@ -94,8 +92,8 @@ export const unsubscribe = firestore.collection(firestoreCollections.USER)
 
 /**
  * Get all stimuli image urls from bucket to display in img tags.
- * @param {*} userId user id
- * @param {*} experimentId experiment id
+ * @param {String} userId user id
+ * @param {String} experimentId experiment id
  * @return {JSON} JSON object including array of processed self image urls
  */
 const getSieStimuliFromBucket = (userId, experimentId) => {

--- a/src/firebase/api/gcp-utils.js
+++ b/src/firebase/api/gcp-utils.js
@@ -55,8 +55,8 @@ const uploadImageToStorage = async (
 export const observeStimuliCompletion =
   async (userId, experimentId, imageUrlsHandler, errorHandler) => {
     // TODO: refactor for multiple experiments inside user doc
-    firestore.collection(firestoreCollections.USER).doc(userId)
-      .onSnapshot(async (doc) => {
+    const subscribe = firestore.collection(firestoreCollections.USER)
+      .doc(userId).onSnapshot(async (doc) => {
         const userDoc = doc.data();
         const stimuliStatus = userDoc.sie_stimuli_generation_status;
         if (stimuliStatus === 'completed') {
@@ -78,6 +78,9 @@ export const observeStimuliCompletion =
           errorHandler(stimuliStatus);
         }
       });
+    setTimeout(() => {
+      subscribe();
+    }, 4000);
   };
 
 

--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -20,6 +20,5 @@ export const auth = firebase.auth();
 export const firestore = firebase.firestore();
 export const storage = firebase.storage();
 export const app = firebase.app();
-export const pubsub = firebase.functions.pubsub;
 
 export default firebase;

--- a/src/stories/components/UploadPhoto/UploadPhoto.js
+++ b/src/stories/components/UploadPhoto/UploadPhoto.js
@@ -8,7 +8,7 @@ import { Button } from '../Button/Button';
 import { ImageGuidelines } from '../ImageGuidelines/ImageGuidelines';
 import { ToggleCamera } from '../ToggleCamera/ToggleCamera';
 import { FileUpload } from '../FileUpload/FileUpload';
-import { uploadSelfImage, observeStimuliCompletion, unsubscribe }
+import { uploadSelfImage, unsubscribe }
   from '../../../firebase/api/gcp-utils';
 import { Loader } from '../Loader/Loader';
 import { StatusCodes } from 'http-status-codes';
@@ -28,19 +28,12 @@ export const UploadPhoto = () => {
   const [error, setError] = useState(false);
   const webcamRef = React.useRef(null);
   const [loading, setLoading] = useState(false);
-  const [urls, setUrls] = useState([]);
   const [complete, setComplete] = useState(false);
+  // TODO: define urls state
 
-  // image URLs handler
-  const imageUrlsHandler = (urlArray) => {
-    setUrls(urlArray);
-  };
+  // TODO: image URLs handler
 
-  // image error handler
-  const errorHandler = (errorMessage) => {
-    // display user message
-    setComplete(false);
-  };
+  // TODO: image error handler
 
   // toggle device camera
   const toggleCamera = () => {
@@ -63,18 +56,14 @@ export const UploadPhoto = () => {
 
   // listen for stimuli completion
   useEffect(() => {
-    // TODO: get userId and experimentId here
-    observeStimuliCompletion('3xOn8cXslDdqjv5ewcQOliuGB0D2', '001',
-      imageUrlsHandler, errorHandler);
+    // TODO: call observeStimuliCompletion here with timer to avoid
+    // long open listeners, should be around 4000ms;
     return () => {
       unsubscribe();
     };
   }, [loading]);
 
-  // check if all urls are fetched
-  useEffect(() => {
-    checkStimuli();
-  }, [urls]);
+  // TODO: useEffect({}, [urls]) to check if all urls are fetched
 
   // check if stimuli generation is successful
   const checkStimuli = () => {
@@ -108,6 +97,8 @@ export const UploadPhoto = () => {
       switch (response.status) {
       case StatusCodes.CREATED:
         setLoading(true);
+        // TODO: move this line to useEffect
+        checkStimuli();
         return;
       case StatusCodes.INTERNAL_SERVER_ERROR:
         setError(true);

--- a/src/stories/components/UploadPhoto/UploadPhoto.js
+++ b/src/stories/components/UploadPhoto/UploadPhoto.js
@@ -70,7 +70,7 @@ export const UploadPhoto = () => {
     };
   }, [loading]);
 
-  // check if all urls are fetched 
+  // check if all urls are fetched
   useEffect(() => {
     checkStimuli();
   }, [urls]);

--- a/src/stories/components/UploadPhoto/UploadPhoto.js
+++ b/src/stories/components/UploadPhoto/UploadPhoto.js
@@ -64,7 +64,8 @@ export const UploadPhoto = () => {
   // listen for stimuli completion
   useEffect(() => {
     // TODO: get userId and experimentId here
-    observeStimuliCompletion('test', '001', imageUrlsHandler, errorHandler);
+    observeStimuliCompletion('3xOn8cXslDdqjv5ewcQOliuGB0D2', '001',
+      imageUrlsHandler, errorHandler);
     return () => {
       unsubscribe();
     };

--- a/src/stories/components/UploadPhoto/UploadPhoto.js
+++ b/src/stories/components/UploadPhoto/UploadPhoto.js
@@ -1,6 +1,6 @@
 import './styles.scss';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Webcam from 'react-webcam';
 
 import { PhotoInstructions } from '../PhotoInstructions/PhotoInstructions';
@@ -8,7 +8,7 @@ import { Button } from '../Button/Button';
 import { ImageGuidelines } from '../ImageGuidelines/ImageGuidelines';
 import { ToggleCamera } from '../ToggleCamera/ToggleCamera';
 import { FileUpload } from '../FileUpload/FileUpload';
-import { uploadSelfImage, unsubscribe }
+import { uploadSelfImage }
   from '../../../firebase/api/gcp-utils';
 import { Loader } from '../Loader/Loader';
 import { StatusCodes } from 'http-status-codes';
@@ -54,14 +54,9 @@ export const UploadPhoto = () => {
     setImage('');
   };
 
-  // listen for stimuli completion
-  useEffect(() => {
-    // TODO: call observeStimuliCompletion here with timer to avoid
-    // long open listeners, should be around 4000ms;
-    return () => {
-      unsubscribe();
-    };
-  }, [loading]);
+  // TODO call useEffect() to listen for stimuli completion
+  // TODO: call observeStimuliCompletion here with timer to avoid
+  // long open listeners, should be around 4000ms;
 
   // TODO: useEffect({}, [urls]) to check if all urls are fetched
 


### PR DESCRIPTION
In this PR:
- Redesigned the process of observing image stimuli generation from Pub/Sub message to firestore document
- Fix the uploadImage path issue.

For frontend:  use `useEffect()` to call for the observe function to get the stimuli-image URLs.