### PR TITLE
BUG revert getCurrentUser

### DIFF
--- a/src/firebase/api/users.js
+++ b/src/firebase/api/users.js
@@ -176,9 +176,7 @@ export const getCurrentUser = () => {
   return new Promise((resolve, reject) => {
     const unsubscribe = auth.onAuthStateChanged((userAuth) => {
       unsubscribe();
-      if (userAuth && (userAuth.isAnonymous || userAuth.emailVerified)) {
-        resolve(userAuth);
-      }
+      resolve(userAuth);
     }, reject);
   });
 };


### PR DESCRIPTION
changes to getCurrentUser were causing an infinite loading screen, reverting this so we can demo, need to speak with firebase team about their new implementation afterwards.