### PR TITLE
SIE-129 added send reset password email for users who are unable to login.

### DIFF
--- a/src/firebase/api/users.js
+++ b/src/firebase/api/users.js
@@ -74,6 +74,33 @@ export const signIn = async (email, password) => {
 };
 
 /**
+ * Send a reset password confirmation email to
+ * user with its email.
+ * @param {string} email valid email in firestore
+ * @return {JSON} HTTP status code
+ * Errors (only list relevant ones):
+ *  Invalid email
+ *  user not found
+ */
+export const sendResetPasswordEmail = async (email) => {
+  const auth = firebase.auth();
+  try {
+    await auth.sendResetPasswordEmail(email);
+    return {
+      status: StatusCodes.OK,
+      data: null,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      status: StatusCodes.NOT_MODIFIED,
+      data: null,
+      error,
+    };
+  }
+};
+
+/**
  * Reset a user password
  * @param {string} newPassword valid password
  * @return {JSON} user auth object or error code


### PR DESCRIPTION
1. When the confirmation email is sent, we do not need to create an additional page for the user to reset his/her password. Firebase generates it for our convenience already. 
2. We can modify the email template in firebase authentication -> Templates -> Password Reset. I already modified it to match with the email verification one.
3. The ```sendResetPasswordEmail``` returns a void promise if it succeeds, thus, the behavior is now if it succeeds, it sends a 200 success code back, 304(Not modified) otherwise. 

@fernandowinfield 
I understand we have a reset password for logged-in user but @bleachalon pointed out that forget password seemed more urgent than reset password. If front-end team hasn't implemented that part, I think we can do this reset password instead. I don't mean to add work onto your team. Just a text field with a send reset password email button will do. 
If you decide not to do this part, it is fine because as we discussed before, no additional feature should be added. This function can be used by who will be working on this project in the future.

references:
https://www.youtube.com/watch?v=wtnjhbt6ipg
https://firebase.google.com/docs/reference/js/firebase.auth.Auth#sendpasswordresetemail
https://console.firebase.google.com/u/0/project/cs6510-spr2021/authentication/emails

