### PR TITLE
[SIE 141] Consent form integration

### DIFF
--- a/src/firebase/test/gcp-util.test.js
+++ b/src/firebase/test/gcp-util.test.js
@@ -4,7 +4,7 @@ import { getSieStimuliFromBucket } from '../api/gcp-utils';
 
 // test observe image stimuli generation completion.
 test('get 400 stimuli image urls from bucket', async () => {
-  const userId = '3xOn8cXslDdqjv5ewcQOliuGB0D2';
+  const userId = 'testuser';
   const experimentId = '002';
 
   // if the user-experiment folder exists, it shall have length of 400

--- a/src/firebase/test/gcp-util.test.js
+++ b/src/firebase/test/gcp-util.test.js
@@ -4,7 +4,7 @@ import { getSieStimuliFromBucket } from '../api/gcp-utils';
 
 // test observe image stimuli generation completion.
 test('get 400 stimuli image urls from bucket', async () => {
-  const userId = 'testuser';
+  const userId = '3xOn8cXslDdqjv5ewcQOliuGB0D2';
   const experimentId = '002';
 
   // if the user-experiment folder exists, it shall have length of 400

--- a/src/stories/layouts/Wizard/Wizard.js
+++ b/src/stories/layouts/Wizard/Wizard.js
@@ -12,8 +12,10 @@ import { Link, useParams } from 'react-router-dom';
  * Component for Wizard layout element.
  * @param {node} children of the component
  * @param {array} labels of steps
+ * @param {bool} showNext Whether to enable the 'Next' button or not
+ * @param {func} stepHandler React hook to share the current step of the Wizard
  * @return {object} (
- *   <Wizard labels={labels}>
+ *   <Wizard labels={labels} showNext={showNext} stepHandler={stepHandler}>
  *       {children}
  *   <Wizard />
  * )
@@ -103,7 +105,10 @@ const Controls = ({ experimentId, currentStep, WizInstance, showNext }) => (
           <Link className={'wizard__button button button--tertiary'}
             to={`/study/${experimentId}/user/123`}
           >Complete Study</Link> :
-          <button className={'wizard__button button button--tertiary disabled'}
+          <button className={'wizard__button ' +
+            'button ' +
+            'button--tertiary ' +
+            'button--disabled'}
           >Next</button>
       }
     </div>

--- a/src/stories/layouts/Wizard/Wizard.js
+++ b/src/stories/layouts/Wizard/Wizard.js
@@ -19,7 +19,7 @@ import { Link, useParams } from 'react-router-dom';
  * )
  */
 /* eslint react/prop-types: 0 */
-export const Wizard = ({ children, labels, showNext }) => {
+export const Wizard = ({ children, labels, showNext, stepHandler }) => {
   const { experimentId } = useParams();
   const [state, updateState] = useState({
     form: {},
@@ -29,6 +29,7 @@ export const Wizard = ({ children, labels, showNext }) => {
   // update step value
   const onStepChange = (stats) => {
     setStep(WizInstance.currentStep);
+    stepHandler(WizInstance.currentStep);
     window.setTimeout(function() {
       window.scrollTo({
         top: 0,
@@ -119,9 +120,13 @@ Wizard.propTypes = {
      */
   labels: PropTypes.array,
   /**
-     * Wizard's 'Next' button condition
+     * Wizard's 'Next' button condition (whether to show it or not)
      */
   showNext: PropTypes.bool,
+  /**
+     * React hook to share the current step of the Wizard
+     */
+  stepHandler: PropTypes.func,
 };
 
 Wizard.defaultProps = {

--- a/src/stories/layouts/Wizard/Wizard.js
+++ b/src/stories/layouts/Wizard/Wizard.js
@@ -142,4 +142,6 @@ Wizard.defaultProps = {
     'Step 3',
     'Step 4',
   ],
+  showNext: true,
+  stepHandler: (step) => step,
 };

--- a/src/stories/layouts/Wizard/Wizard.js
+++ b/src/stories/layouts/Wizard/Wizard.js
@@ -98,18 +98,13 @@ const Controls = ({ experimentId, currentStep, WizInstance, showNext }) => (
           onClick={WizInstance.previousStep}
         >Go Back</button>
       }
-      {(currentStep !== WizInstance.totalSteps && showNext) ?
+      {currentStep === WizInstance.totalSteps ?
+        <Link className={'wizard__button button button--tertiary'}
+          to={`/study/${experimentId}/user/123`}
+        >Complete Study</Link> :
         <button className={'wizard__button button button--tertiary'}
-          onClick={WizInstance.nextStep}
-        >Next</button> : currentStep === WizInstance.totalSteps ?
-          <Link className={'wizard__button button button--tertiary'}
-            to={`/study/${experimentId}/user/123`}
-          >Complete Study</Link> :
-          <button className={'wizard__button ' +
-            'button ' +
-            'button--tertiary ' +
-            'button--disabled'}
-          >Next</button>
+          onClick={WizInstance.nextStep} disabled={!showNext}
+        >Next</button>
       }
     </div>
   </Fragment>

--- a/src/stories/layouts/Wizard/Wizard.js
+++ b/src/stories/layouts/Wizard/Wizard.js
@@ -19,7 +19,7 @@ import { Link, useParams } from 'react-router-dom';
  * )
  */
 /* eslint react/prop-types: 0 */
-export const Wizard = ({ children, labels }) => {
+export const Wizard = ({ children, labels, showNext }) => {
   const { experimentId } = useParams();
   const [state, updateState] = useState({
     form: {},
@@ -60,7 +60,9 @@ export const Wizard = ({ children, labels }) => {
         </StepWizard>
         {
           WizInstance && <Controls currentStep={step}
-            WizInstance={WizInstance} experimentId={experimentId} />
+            WizInstance={WizInstance}
+            experimentId={experimentId}
+            showNext={showNext} />
         }
       </Fragment>
     );
@@ -85,7 +87,7 @@ export const Wizard = ({ children, labels }) => {
  *   <Fragment WizInstance={WizInstance} />
  * )
  */
-const Controls = ({ experimentId, currentStep, WizInstance }) => (
+const Controls = ({ experimentId, currentStep, WizInstance, showNext }) => (
   <Fragment>
     <div className="wizard__controls">
       {currentStep !== 1 &&
@@ -93,13 +95,15 @@ const Controls = ({ experimentId, currentStep, WizInstance }) => (
           onClick={WizInstance.previousStep}
         >Go Back</button>
       }
-      {currentStep !== WizInstance.totalSteps ?
+      {(currentStep !== WizInstance.totalSteps && showNext) ?
         <button className={'wizard__button button button--tertiary'}
           onClick={WizInstance.nextStep}
-        >Next</button> :
-        <Link className={'wizard__button button button--tertiary'}
-          to={`/study/${experimentId}/user/123`}
-        >Completet Study</Link>
+        >Next</button> : currentStep === WizInstance.totalSteps ?
+          <Link className={'wizard__button button button--tertiary'}
+            to={`/study/${experimentId}/user/123`}
+          >Complete Study</Link> :
+          <button className={'wizard__button button button--tertiary disabled'}
+          >Next</button>
       }
     </div>
   </Fragment>
@@ -114,6 +118,10 @@ Wizard.propTypes = {
      * Wizard's labels
      */
   labels: PropTypes.array,
+  /**
+     * Wizard's 'Next' button condition
+     */
+  showNext: PropTypes.bool,
 };
 
 Wizard.defaultProps = {

--- a/src/stories/layouts/Wizard/Wizard.stories.js
+++ b/src/stories/layouts/Wizard/Wizard.stories.js
@@ -1,6 +1,7 @@
 import '../../../scss/styles.scss';
 
 import React from 'react';
+import { MemoryRouter } from 'react-router';
 import { Wizard } from './Wizard';
 
 /**
@@ -13,36 +14,38 @@ export default {
 
 const Template = (args) => {
   return (
-    <Wizard {...args}>
-      <div className="step-1">
-        <h3>Step 1</h3>
-                Lorem ipsum dolor sit amet, an has summo
-                riure epicuri, has illud rationibus et. Prima ridens sit te,
-                nam idque explicari expetendis in. An mei adolescens mnesarchum,
-                ei periculis adipiscing per, probo populo nec ad.
-      </div>
-      <div className="step-2">
-        <h3>Step 2</h3>
-                Lorem ipsum dolor sit amet, an has summo
-                riure epicuri, has illud rationibus et. Prima ridens sit te,
-                nam idque explicari expetendis in. An mei adolescens mnesarchum,
-                ei periculis adipiscing per, probo populo nec ad.
-      </div>
-      <div className="step-3">
-        <h3>Step 3</h3>
-                Lorem ipsum dolor sit amet, an has summo
-                riure epicuri, has illud rationibus et. Prima ridens sit te,
-                nam idque explicari expetendis in. An mei adolescens mnesarchum,
-                ei periculis adipiscing per, probo populo nec ad.
-      </div>
-      <div className="step-4">
-        <h3>Step 4</h3>
-                Lorem ipsum dolor sit amet, an has summo
-                riure epicuri, has illud rationibus et. Prima ridens sit te,
-                nam idque explicari expetendis in. An mei adolescens mnesarchum,
-                ei periculis adipiscing per, probo populo nec ad.
-      </div>
-    </Wizard>
+    <MemoryRouter initialEntries={['/user/Pl3WJYa7vQ1ALVt0rHRV/study/108']}>
+      <Wizard {...args}>
+        <div className="step-1">
+          <h3>Step 1</h3>
+                  Lorem ipsum dolor sit amet, an has summo
+                  riure epicuri, has illud rationibus et. Prima ridens sit te,
+                  nam idque explicari expetendis in. An mei adolesce mnesarchum,
+                  ei periculis adipiscing per, probo populo nec ad.
+        </div>
+        <div className="step-2">
+          <h3>Step 2</h3>
+                  Lorem ipsum dolor sit amet, an has summo
+                  riure epicuri, has illud rationibus et. Prima ridens sit te,
+                  nam idque explicari expetendis in. An mei adolesc mnesarchum,
+                  ei periculis adipiscing per, probo populo nec ad.
+        </div>
+        <div className="step-3">
+          <h3>Step 3</h3>
+                  Lorem ipsum dolor sit amet, an has summo
+                  riure epicuri, has illud rationibus et. Prima ridens sit te,
+                  nam idque explicari expetendis in. An mei adolesc mnesarchum,
+                  ei periculis adipiscing per, probo populo nec ad.
+        </div>
+        <div className="step-4">
+          <h3>Step 4</h3>
+                  Lorem ipsum dolor sit amet, an has summo
+                  riure epicuri, has illud rationibus et. Prima ridens sit te,
+                  nam idque explicari expetendis in. An mei adolesc mnesarchum,
+                  ei periculis adipiscing per, probo populo nec ad.
+        </div>
+      </Wizard>
+    </MemoryRouter>
   );
 };
 

--- a/src/stories/layouts/Wizard/styles.scss
+++ b/src/stories/layouts/Wizard/styles.scss
@@ -72,4 +72,10 @@
       font-size: $font-size-md;
     }
   }
+
+  &.button--disabled {
+    opacity: 0.15;
+    pointer-events: none;
+    background-color: $gray-3;
+  }
 }

--- a/src/stories/pages/Experiment/Experiment.js
+++ b/src/stories/pages/Experiment/Experiment.js
@@ -1,4 +1,3 @@
-/*eslint-disable*/
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
@@ -36,6 +35,8 @@ export const Experiment = ({
   const { experimentId, participantId } = useParams();
   const [experiment, setExperiment] = useState({});
   const [showNext, setShowNext] = useState(true);
+  const [wizardStep, setWizardStep] = useState(1);
+  const [consentResponse, setConsentResponse] = useState(null);
 
   useEffect(() => {
     const id = experimentId ?
@@ -46,16 +47,31 @@ export const Experiment = ({
     });
   }, []);
 
-  // useEffect(async () => {
-  //   if (experiment) {
-  //     const consentResult = await getConsentResult(participantId, experimentId);
-  //     if (consentResult.data.response) {
-  //       setShowNext(true);
-  //     } else {
-  //       window.alert('Couldn\'t get consent response');
-  //     }
-  //   }
-  // }, [experiment]);
+  useEffect(() => {
+    if (wizardStep === 2) {
+      getConsentResult(participantId, experimentId, setConsentResponse);
+    } else if (wizardStep === 3) {
+      setShowNext(true);
+    } else if (wizardStep === 4) {
+      setShowNext(true);
+    } else if (wizardStep === 5) {
+      setShowNext(true);
+    } else if (wizardStep === 6) {
+      setShowNext(true);
+    } else if (wizardStep !== 1) {
+      setShowNext(false);
+    }
+  }, [wizardStep]);
+
+  useEffect(() => {
+    if (consentResponse) {
+      if (consentResponse.data.response === 'Agree') {
+        setShowNext(true);
+      } else if (consentResponse.data.response === 'Disagree') {
+        // What do we do if participant doesn't give consent?
+      }
+    }
+  }, [consentResponse]);
 
   const HEADING = 'h3';
   const steps = [
@@ -75,7 +91,10 @@ export const Experiment = ({
       />
       <div className="experiment">
         <Constrain>
-          <Wizard labels={steps} showNext={showNext}>
+          <Wizard labels={steps}
+            showNext={showNext}
+            stepHandler={setWizardStep}
+          >
             {/* Step 1 */}
             <Section titleEl={HEADING} title='Introduction'>
               <h4>{experiment.title}</h4>
@@ -85,9 +104,9 @@ export const Experiment = ({
             <Section titleEl={HEADING} title='Consent Form'>
               <p>Please, complete the form below before completing the
                 study.</p>
-              <QualtricsEmbed url={`${experiment.consent}?
-                participant_id=${participantId}&
-                experiment_id=${experimentId}}`} />
+              <QualtricsEmbed url={`${experiment.consent}`+
+                `?participant_id=${participantId}` +
+                `&experiment_id=${experimentId}`} />
             </Section>
             {/* Step 3 */}
             <Section titleEl={HEADING} title='Photo Instructions and Upload'>

--- a/src/stories/pages/Experiment/Experiment.js
+++ b/src/stories/pages/Experiment/Experiment.js
@@ -60,6 +60,8 @@ export const Experiment = ({
       show = true;
     } else if (wizardStep === 2) {
       getConsentResult(participantId, experimentId, setConsentResponse);
+      /* eslint-disable */
+      console.log(consentResponse);
     }
     setShowNext(show);
   }, [wizardStep]);

--- a/src/stories/pages/Experiment/Experiment.js
+++ b/src/stories/pages/Experiment/Experiment.js
@@ -33,9 +33,16 @@ export const Experiment = ({
   preSurveys, postSurveys,
 }) => {
   const { experimentId, participantId } = useParams();
+  // Experiment metadata
   const [experiment, setExperiment] = useState({});
+  // Enable/disable 'Next' button of Wizard
   const [showNext, setShowNext] = useState(true);
+  // Track the step the Wizard is at
   const [wizardStep, setWizardStep] = useState(1);
+  // Keep track of already completed steps
+  // TODO: 3, 4, 5, and 6 should be removed once respective step is fully
+  // integrated.
+  const [completedSteps, setCompletedSteps] = useState([1, 3, 4, 5, 6]);
   const [consentResponse, setConsentResponse] = useState(null);
 
   useEffect(() => {
@@ -48,27 +55,22 @@ export const Experiment = ({
   }, []);
 
   useEffect(() => {
-    if (wizardStep === 2) {
+    let show = false;
+    if (completedSteps.includes(wizardStep)) {
+      show = true;
+    } else if (wizardStep === 2) {
       getConsentResult(participantId, experimentId, setConsentResponse);
-    } else if (wizardStep === 3) {
-      setShowNext(true);
-    } else if (wizardStep === 4) {
-      setShowNext(true);
-    } else if (wizardStep === 5) {
-      setShowNext(true);
-    } else if (wizardStep === 6) {
-      setShowNext(true);
-    } else if (wizardStep !== 1) {
-      setShowNext(false);
     }
+    setShowNext(show);
   }, [wizardStep]);
 
   useEffect(() => {
-    if (consentResponse) {
+    if (consentResponse && consentResponse.data) {
       if (consentResponse.data.response === 'Agree') {
         setShowNext(true);
+        setCompletedSteps((prevState) => [...prevState, 2]);
       } else if (consentResponse.data.response === 'Disagree') {
-        // What do we do if participant doesn't give consent?
+        // TODO: What do we do if participant doesn't give consent?
       }
     }
   }, [consentResponse]);

--- a/src/stories/pages/Experiment/Experiment.js
+++ b/src/stories/pages/Experiment/Experiment.js
@@ -1,3 +1,4 @@
+/*eslint-disable*/
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
@@ -12,6 +13,7 @@ import { Section } from '../../components/Section/Section';
 import { ImageSelectionTask }
   from '../../components/ImageSelectionTask/ImageSelectionTask';
 import { getExperimentById } from '../../../firebase/api/experiments';
+import { getConsentResult } from '../../../firebase/api/qualtrics';
 
 /**
  * Component for experiment page.
@@ -33,6 +35,7 @@ export const Experiment = ({
 }) => {
   const { experimentId, participantId } = useParams();
   const [experiment, setExperiment] = useState({});
+  const [showNext, setShowNext] = useState(true);
 
   useEffect(() => {
     const id = experimentId ?
@@ -42,6 +45,17 @@ export const Experiment = ({
       setExperiment(res.data);
     });
   }, []);
+
+  // useEffect(async () => {
+  //   if (experiment) {
+  //     const consentResult = await getConsentResult(participantId, experimentId);
+  //     if (consentResult.data.response) {
+  //       setShowNext(true);
+  //     } else {
+  //       window.alert('Couldn\'t get consent response');
+  //     }
+  //   }
+  // }, [experiment]);
 
   const HEADING = 'h3';
   const steps = [
@@ -61,7 +75,7 @@ export const Experiment = ({
       />
       <div className="experiment">
         <Constrain>
-          <Wizard labels={steps}>
+          <Wizard labels={steps} showNext={showNext}>
             {/* Step 1 */}
             <Section titleEl={HEADING} title='Introduction'>
               <h4>{experiment.title}</h4>


### PR DESCRIPTION
Integrated Consent form Qualtrics survey into Experiment flow. Had to add a couple of parameters to the Wizard component to be able to communicate state between that component and the Experiment component.

To test:
- `npm start`
- Go to http://localhost:3000/9iG2wajKXkjLXiLQfwgj/36qwRoyuSzcHzvCAapya4hrJBgQ2
- Move to step 2 of the Wizard and complete the Qualtrics survey. If agreed to the consent form, the 'Next' button should be enabled and you should be able to continue to the next steps of the experiment.
- Note: these steps assume that the user doc `36qwRoyuSzcHzvCAapya4hrJBgQ2` does not have any Experiment collections in Firestore (in other words, the participant must not have done this experiment before).

Jira [ticket](https://cs6510.atlassian.net/browse/SIE-141)