### PR TITLE
Dont allow Modal closing until experiment is done

### DIFF
--- a/src/stories/components/ImageSelectionTask/ImageSelectionTask.js
+++ b/src/stories/components/ImageSelectionTask/ImageSelectionTask.js
@@ -18,8 +18,11 @@ import { Modal } from '../../components/Modal/Modal';
  *   <ImageSelectionTask url={url} />
  * )
  */
-export const ImageSelectionTask = ({ url, selectionTaskCompletionHandler }) => {
-  const [hideTask, setHideTask] = useState(true);
+export const ImageSelectionTask = ({
+  url,
+  selectionTaskCompleted,
+  selectionTaskCompletionHandler,
+}) => {
   return (
     <Fragment>
       {/* <p>In the following computer task, you will complete a series of*/}
@@ -41,14 +44,7 @@ export const ImageSelectionTask = ({ url, selectionTaskCompletionHandler }) => {
       {/*  There are no wrong answers, so GO AS FAST AS YOU CAN.*/}
       {/*  Responses that are too slow will not be recorded.</p>*/}
       {/* <p>To get started, <a href={url}>click here</a>.</p>*/}
-
-      {/* <Button
-        isButton={true}
-        onClick={() => setHideTask(false)}
-        text="Start Experiment"
-      />
-      <ScreenTakeover isHidden={hideTask}> */}
-      <Modal buttonText="Start Experiment">
+      <Modal buttonText="Start Experiment" canClose={selectionTaskCompleted}>
         <JsPsych
           selectionTaskCompletionHandler={selectionTaskCompletionHandler}
         />
@@ -63,6 +59,10 @@ ImageSelectionTask.propTypes = {
    * ImageSelectionTask's url
    */
   url: PropTypes.string.isRequired,
+  /**
+   * ImageSelectionTask's prop to know if the task is complete
+   */
+  selectionTaskCompleted: PropTypes.bool,
   /**
    * ImageSelectionTask's completion handler
    */

--- a/src/stories/components/ImageSelectionTask/ImageSelectionTask.js
+++ b/src/stories/components/ImageSelectionTask/ImageSelectionTask.js
@@ -25,31 +25,34 @@ export const ImageSelectionTask = ({
 }) => {
   return (
     <Fragment>
-      {/* <p>In the following computer task, you will complete a series of*/}
-      {/*  trials where you will be asked to make a split-second*/}
-      {/*  choice between two images of yourself.</p>*/}
-      {/* <p>Each image is based on an actual photograph of you, but there */}
-      {/*  is noise/*/}
-      {/*  static on top of the photo that may alter its appearance.*/}
-      {/*  The differences between the two images may be quite subtle,*/}
-      {/*  so we ask that you go with your gut.</p>*/}
-      {/* <p>Two pictures will appear side by side on the screen.*/}
-      {/*  For each pair of pictures, we would like you to select the */}
-      {/*  picture that*/}
-      {/*  is most like you. To select the image on the left side press the */}
-      {/* E key;*/}
-      {/*  to select the image on the right press the I key.</p>*/}
-      {/* <p>This task is timed and will take approximately 20 minutes to */}
-      {/* complete.*/}
-      {/*  There are no wrong answers, so GO AS FAST AS YOU CAN.*/}
-      {/*  Responses that are too slow will not be recorded.</p>*/}
-      {/* <p>To get started, <a href={url}>click here</a>.</p>*/}
+      <p>
+        In the following computer task, you will complete a series of trials
+        where you will be asked to make a split-second choice between two images
+        of yourself.
+      </p>
+      <p>
+        Each image is based on an actual photograph of you, but there is noise/
+        static on top of the photo that may alter its appearance. The
+        differences between the two images may be quite subtle, so we ask that
+        you go with your gut.
+      </p>
+      <p>
+        Two pictures will appear side by side on the screen. For each pair of
+        pictures, we would like you to select the picture that is most like you.
+        To select the image on the left side press the E key; to select the
+        image on the right press the I key.
+      </p>
+      <p>
+        This task is timed and will take approximately 20 minutes to complete.
+        There are no wrong answers, so GO AS FAST AS YOU CAN. Responses that are
+        too slow will not be recorded.
+      </p>
+      <p>To get started</p>
       <Modal buttonText="Start Experiment" canClose={selectionTaskCompleted}>
         <JsPsych
           selectionTaskCompletionHandler={selectionTaskCompletionHandler}
         />
       </Modal>
-      {/* </ScreenTakeover> */}
     </Fragment>
   );
 };

--- a/src/stories/components/Modal/Modal.js
+++ b/src/stories/components/Modal/Modal.js
@@ -16,6 +16,7 @@ import { fadeIn, fadeOut } from '../../../utils/utils';
  * @param {string} buttonText Text to appear on the modal's open button.
  * @param {string} buttonModifierClasses Class modifiers of the modal's open
  * button.
+ * @param {bool} canClose bool to denote whether the modal is closable
  * @param {func} onClose cleanup method to be ran when the modal is closed
  * @return {object} (
  *   <Modal>
@@ -27,11 +28,12 @@ export const Modal = ({
   children,
   buttonText,
   buttonModifierClasses,
+  canClose,
   onClose,
 }) => {
   const [modalOpen, setModalOpen] = useState(false);
   const modalRef = useRef(null);
-  // const [modalClasses, setModalClasses] = useState('modal--content');
+
   const toggleModal = () => {
     if (onClose && modalOpen) {
       onClose();
@@ -63,7 +65,11 @@ export const Modal = ({
       />
       <div className="modal" ref={modalRef}>
         <div className="modal__content">
-          <button className="modal__content--close" onClick={toggleModal} />
+          <button
+            className="modal__content--close"
+            onClick={toggleModal}
+            disabled={!canClose}
+          />
           <Constrain modifierClasses="constrain--narrow">{children}</Constrain>
         </div>
       </div>
@@ -77,13 +83,17 @@ Modal.propTypes = {
    */
   children: PropTypes.node,
   /**
-   * Button's Text
+   * Modal's Button Text
    */
   buttonText: PropTypes.string.isRequired,
   /**
    * Button's modifier classes
    */
   buttonModifierClasses: PropTypes.string,
+  /**
+   * Buttons canClose value
+   */
+  canClose: PropTypes.bool,
   /**
    * Button's onClose cleanup
    */
@@ -92,5 +102,6 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   buttonText: 'Open Modal',
+  canClose: true,
   onClose: null,
 };

--- a/src/stories/components/Modal/styles.scss
+++ b/src/stories/components/Modal/styles.scss
@@ -50,6 +50,10 @@
   position: absolute;
   top: $spacing-9;
   width: 24px;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
 }
 
 /* Custom button used in ExperimentsPage */

--- a/src/stories/pages/Experiment/Experiment.js
+++ b/src/stories/pages/Experiment/Experiment.js
@@ -157,6 +157,7 @@ export const Experiment = ({ preSurveys, postSurveys }) => {
             {/* Step 5 */}
             <Section titleEl={HEADING} title="Image Selection Task">
               <ImageSelectionTask
+                selectionTaskCompleted={selectionTaskCompleted}
                 selectionTaskCompletionHandler={setSelectionTaskCompleted}
               />
             </Section>


### PR DESCRIPTION
The selection task uses the `Modal` component to takeover the whole screen. We wanted to disable the close button if the experiment is ongoing.

Added `canClose` prop to be passed into the `Modal` that disables the close button.
Added instructions back into the `ImageSelectionTask`
The cursor when hovering over the close button should be a red cross and clicking it does nothing.
