### PR TITLE
Updating Modal/Button class to contain an additional parameter to disable button

### DIFF
--- a/src/stories/components/Button/Button.js
+++ b/src/stories/components/Button/Button.js
@@ -19,7 +19,8 @@ import { Link } from 'react-router-dom';
  * )
  */
 export const Button =
-({ modifierClasses, url, text, isButton, onClick }) => {
+({ modifierClasses, url, text, isButton,
+  onClick, disableBtn }) => {
   const classes = ['button', `${modifierClasses}`].join(' ').trim();
 
   return (
@@ -29,6 +30,7 @@ export const Button =
           role="button"
           className={classes}
           onClick={onClick}
+          disabled={disableBtn}
         >
           {text}
         </button> :
@@ -59,6 +61,10 @@ Button.propTypes = {
      * Button's onClick
      */
   onClick: PropTypes.func,
+  /**
+   * Button's disableBtn
+   */
+  disableBtn: PropTypes.bool,
 };
 
 Button.defaultProps = {

--- a/src/stories/components/ImageSelectionTask/ImageSelectionTask.js
+++ b/src/stories/components/ImageSelectionTask/ImageSelectionTask.js
@@ -48,7 +48,8 @@ export const ImageSelectionTask = ({
         too slow will not be recorded.
       </p>
       <p>To get started</p>
-      <Modal buttonText="Start Experiment" canClose={selectionTaskCompleted}>
+      <Modal buttonText="Start Experiment"
+        selectionTaskComplete={selectionTaskCompleted}>
         <JsPsych
           selectionTaskCompletionHandler={selectionTaskCompletionHandler}
         />

--- a/src/stories/components/Modal/Modal.js
+++ b/src/stories/components/Modal/Modal.js
@@ -16,7 +16,7 @@ import { fadeIn, fadeOut } from '../../../utils/utils';
  * @param {string} buttonText Text to appear on the modal's open button.
  * @param {string} buttonModifierClasses Class modifiers of the modal's open
  * button.
- * @param {bool} canClose bool to denote whether the modal is closable
+ * @param {bool} selectionTaskComplete bool to denote whether modal is closable
  * @param {func} onClose cleanup method to be ran when the modal is closed
  * @return {object} (
  *   <Modal>
@@ -28,7 +28,7 @@ export const Modal = ({
   children,
   buttonText,
   buttonModifierClasses,
-  canClose,
+  selectionTaskComplete,
   onClose,
 }) => {
   const [modalOpen, setModalOpen] = useState(false);
@@ -62,13 +62,14 @@ export const Modal = ({
         onClick={toggleModal}
         text={buttonText}
         isButton={true}
+        disableBtn={selectionTaskComplete}
       />
       <div className="modal" ref={modalRef}>
         <div className="modal__content">
           <button
             className="modal__content--close"
             onClick={toggleModal}
-            disabled={!canClose}
+            disabled={!selectionTaskComplete}
           />
           <Constrain modifierClasses="constrain--narrow">{children}</Constrain>
         </div>
@@ -91,9 +92,9 @@ Modal.propTypes = {
    */
   buttonModifierClasses: PropTypes.string,
   /**
-   * Buttons canClose value
+   * Buttons selectionTaskComplete value
    */
-  canClose: PropTypes.bool,
+  selectionTaskComplete: PropTypes.bool,
   /**
    * Button's onClose cleanup
    */
@@ -102,6 +103,7 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   buttonText: 'Open Modal',
-  canClose: true,
+  selectionTaskComplete: false,
   onClose: null,
+  disableBtn: false,
 };


### PR DESCRIPTION
We want to hide/disable "Start Experiment" button (in image selection task section) when the task is finished. Reason being we don't want users to be able to reopen modal. We'd rather disable the button, so that they're only option is to click the "Next" button to continue with the experiment sections. 

Here are the major changes:

- Updating Button.js to contain an additional parameter "disableBtn" which will be used to set the react button class's 'disabled' field. If the user finishes the selection task, the button will be disabled. 
- Updating Modal.js to reflect changes mentioned above - adding a 'disabledBtn' class to the Button component.
- Changing 'canClose' variable name to 'selctionTaskComplete' so that we can use it for both Modal close feature + disable button feature.

Expected behavior:
- Users can click "Start Experiment" to open up modal which loads JsPsych component to conduct image selection task. 
- When users are done with JsPsych component, they are able to close out of the modal, and they will see that the "Start Experiment" button is disabled / hidden. 