### PR TITLE
[SIE-151] Reorganize experiment fields

### DIFF
--- a/src/firebase/api/experiments.js
+++ b/src/firebase/api/experiments.js
@@ -40,9 +40,7 @@ export const getAllExperiments = async () => {
     const res = [];
     if (!snapshot.empty) {
       snapshot.forEach((doc) => {
-        // TODO(qhoang) let's not send back all information but
-        // only those necessary for frontend
-        res.push(doc.data());
+        res.push({ ...doc.data(), experimentId: doc.id });
       });
     }
 

--- a/src/stories/components/Card/Card.js
+++ b/src/stories/components/Card/Card.js
@@ -1,6 +1,6 @@
 import './styles.scss';
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '../Button/Button';
 
@@ -9,29 +9,52 @@ import { Button } from '../Button/Button';
  *
  * @component
  * @param {string} modifierClasses Class modifiers of the component.
- * @param {sting} title Text found for the title of the card
- * @param {string} body Text found in the body of the card
- * @param {string} opened Date the experiment will be opened
- * @param {string} admin The admin for the experiment
- * @param {string} researchers The researchers for the experiment
+ * @param {object} experimentInfo The metadata of an experiment
  * @return {object}
  *   <Card
  *      modifierClasses={modifierClasses}
- *      title={text}
- *      text={text}
- *      opened={opened}
- *      admin={admin}
- *      researchesr={researchers} />
+ *      experimentInfo={experimentInfo} />
  * )
  */
 export const Card = ({
   modifierClasses,
-  title,
-  body,
-  opened,
-  admin,
-  researchers,
+  experimentInfo,
 }) => {
+  const {
+    title,
+    body,
+    opened,
+    creator,
+    consentForm,
+    preSurvey,
+    postSurvey,
+    experimentUrl,
+  } = experimentInfo;
+
+  const [showDetails, setShowDetails] = useState(false);
+
+  // To show/hide experiment details
+  const toggleDetails = () => {
+    setShowDetails((prevState) => !prevState);
+  };
+
+  const cardDetails = showDetails ?
+    <React.Fragment>
+      <hr/>
+      <p>Consent form Qualtrics survey:</p>
+      <p>{consentForm}</p>
+      <hr/>
+      <p>Pre-experiment Qualtrics survey:</p>
+      <p>{preSurvey}</p>
+      <hr/>
+      <p>Post-experiment Qualtrics survey:</p>
+      <p>{postSurvey}</p>
+      <hr/>
+      <p>Experiment URL:</p>
+      <p>{experimentUrl}</p>
+    </React.Fragment> :
+    null;
+
   return (
     <div className={['card', `${modifierClasses}`].join(' ').trim()}>
       <div className="card__container">
@@ -41,13 +64,23 @@ export const Card = ({
         </div>
         <div className="card__extra">
           <p>Opened: {opened}</p>
-          <p>Admin: {admin}</p>
-          <p>Researchers: {researchers}</p>
+          <p>Creator: {creator}</p>
+          {cardDetails}
         </div>
-        <Button
-          text="View Details"
-          modifierClasses="button--small card__button"
-        ></Button>
+        {showDetails ?
+          <Button
+            text="Hide Details"
+            modifierClasses="button--small card__button"
+            isButton={true}
+            onClick={toggleDetails}
+          ></Button> :
+          <Button
+            text="View Details"
+            modifierClasses="button--small card__button"
+            isButton={true}
+            onClick={toggleDetails}
+          ></Button>
+        }
       </div>
     </div>
   );
@@ -59,25 +92,9 @@ Card.propTypes = {
      */
   modifierClasses: PropTypes.string,
   /**
-     * Card's title
+     * The experiment's metadata to be displayed in the card
      */
-  title: PropTypes.string.isRequired,
-  /**
-     * Card's body
-     */
-  body: PropTypes.string,
-  /**
-     * The open date
-     */
-  opened: PropTypes.string.isRequired,
-  /**
-     * The admin
-     */
-  admin: PropTypes.string.isRequired,
-  /**
-     * The researchers
-     */
-  researchers: PropTypes.string.isRequired,
+  experimentInfo: PropTypes.object.isRequired,
 };
 
 Card.defaultProps = {

--- a/src/stories/components/Card/Card.js
+++ b/src/stories/components/Card/Card.js
@@ -41,16 +41,16 @@ export const Card = ({
   const cardDetails = showDetails ?
     <React.Fragment>
       <hr/>
-      <p>Consent form Qualtrics survey:</p>
+      <h5>Consent form Qualtrics survey:</h5>
       <p>{consentForm}</p>
       <hr/>
-      <p>Pre-experiment Qualtrics survey:</p>
+      <h5>Pre-experiment Qualtrics survey:</h5>
       <p>{preSurvey}</p>
       <hr/>
-      <p>Post-experiment Qualtrics survey:</p>
+      <h5>Post-experiment Qualtrics survey:</h5>
       <p>{postSurvey}</p>
       <hr/>
-      <p>Experiment URL:</p>
+      <h5>Experiment URL:</h5>
       <p>{experimentUrl}</p>
     </React.Fragment> :
     null;

--- a/src/stories/pages/AddExperiment/AddExperiment.js
+++ b/src/stories/pages/AddExperiment/AddExperiment.js
@@ -99,6 +99,7 @@ export const AddExperiment = ({ buttonText, buttonModifierClasses }) => {
               consent: e.target.value,
             })}
           />
+          <h5>Pre-experiment survey</h5>
           <FormItem
             placeholder="URL to Pre-Survey Questionnaire"
             type="text"
@@ -109,6 +110,7 @@ export const AddExperiment = ({ buttonText, buttonModifierClasses }) => {
               preSurvey: e.target.value,
             })}
           />
+          <h5>Post-experiment survey</h5>
           <FormItem
             placeholder="URL to Post-Survey Questionnaire"
             type="text"

--- a/src/stories/pages/AddExperiment/AddExperiment.js
+++ b/src/stories/pages/AddExperiment/AddExperiment.js
@@ -7,6 +7,7 @@ import { Button } from '../../components/Button/Button';
 import { Modal } from '../../components/Modal/Modal';
 import { createExperiment } from '../../../firebase/api/experiments';
 import { Section } from '../../components/Section/Section';
+import { useAuth } from '../../../contexts/auth-provider';
 
 /**
  * Component for AddExperiment page.
@@ -22,8 +23,8 @@ import { Section } from '../../components/Section/Section';
  */
 
 export const AddExperiment = ({ buttonText, buttonModifierClasses }) => {
-  const [error, setError] = useState('');
-  const [experiment, setExperiment] = useState({
+  const { user } = useAuth(); // Need the user info to know who is the creator
+  const DEFAULT_EXPERIMENT_INFO = {
     title: '',
     description: '',
     date: (new Date()).toLocaleString('default', {
@@ -31,10 +32,14 @@ export const AddExperiment = ({ buttonText, buttonModifierClasses }) => {
       month: 'long',
       day: 'numeric',
     }),
+    creator: user.firstName + ' ' + user.lastName,
     consent: '',
     preSurvey: '',
     postSurvey: '',
-  });
+    isOngoing: true,
+  };
+  const [error, setError] = useState('');
+  const [experiment, setExperiment] = useState(DEFAULT_EXPERIMENT_INFO);
 
   const postExperiment = async (e) => {
     e.preventDefault();
@@ -42,18 +47,7 @@ export const AddExperiment = ({ buttonText, buttonModifierClasses }) => {
     // post experiment
     await createExperiment(experiment).then((response) => {
       if (response.data) {
-        setExperiment({
-          title: '',
-          description: '',
-          date: (new Date()).toLocaleString('default', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          }),
-          consent: '',
-          preSurvey: '',
-          postSurvey: '',
-        });
+        setExperiment(DEFAULT_EXPERIMENT_INFO); // Reset form
 
         // reset form
         e.target.parentNode.reset();

--- a/src/stories/pages/AddExperiment/AddExperiment.test.js
+++ b/src/stories/pages/AddExperiment/AddExperiment.test.js
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { configure } from 'enzyme';
 import { AddExperiment } from './AddExperiment';
+import { AuthContext } from '../../../contexts/auth-provider';
 
 configure({ adapter: new Adapter() });
 
@@ -10,7 +11,12 @@ configure({ adapter: new Adapter() });
 describe('<AddExperiment />', () => {
   // Test header text is rendered and button shows up
   it('renders correctly', () => {
-    const { getAllByText } = render(<AddExperiment />);
+    const user = jest.fn();
+    const { getAllByText } = render(
+      <AuthContext.Provider value={{ user }}>
+        <AddExperiment />
+      </AuthContext.Provider>,
+    );
     expect(getAllByText(/Add New Experiment/i)).toHaveLength(2);
   });
 });

--- a/src/stories/pages/ExperimentsPage/ExperimentsPage.js
+++ b/src/stories/pages/ExperimentsPage/ExperimentsPage.js
@@ -2,13 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { Slider } from '../../components/Slider/Slider';
 import { Card } from '../../components/Card/Card';
 import { AddExperiment } from '../AddExperiment/AddExperiment';
-// eslint-disable-next-line max-len
-import { HorizontalTitle } from '../../components/HorizontalTitle/HorizontalTitle';
+import { HorizontalTitle }
+  from '../../components/HorizontalTitle/HorizontalTitle';
 import { getAllExperiments } from '../../../firebase/api/experiments';
 import { Constrain } from '../../layouts/Constrain/Constrain';
 import { useAuth } from '../../../contexts/auth-provider';
 
-const MAX_DESCRIPTION_LENGTH = 100;
 
 const PLACEHOLDER_EXPERIMENTS = [
   { title: 'Title 1', description: 'Short description' },
@@ -56,9 +55,7 @@ export const ExperimentsPage = () => {
     ongoingExperiments.map((exp, i) => {
       const experimentInfo = {
         title: exp.title,
-        body: exp.description.length > MAX_DESCRIPTION_LENGTH ?
-          exp.description.substring(0, MAX_DESCRIPTION_LENGTH) + '...' :
-          exp.description,
+        body: exp.description,
         opened: exp.date,
         creator: exp.creator,
         consentForm: exp.consent,
@@ -84,9 +81,7 @@ export const ExperimentsPage = () => {
     inactiveExperiments.map((exp, i) => {
       const experimentInfo = {
         title: exp.title,
-        body: exp.description.length > MAX_DESCRIPTION_LENGTH ?
-          exp.description.substring(0, MAX_DESCRIPTION_LENGTH) + '...' :
-          exp.description,
+        body: exp.description,
         opened: exp.date,
         creator: exp.creator,
         consentForm: exp.consent,


### PR DESCRIPTION
### TLDR:
- Reorganized the fields of the Firestore **experiment** doc data model to be able to display more useful data in the Experiments page.
- Resolved pending TODOs in ExperimentsPage component.

*****

### In this PR:
- Updates to the experiment data model:
    - Removed fields:
        - admin
        - researcher
    - New fields:
        - creator
        - preSurvey
        - postSurvey
        - isOngoing

- Updates to Card component:
    - reduced most of the params of <Card/> into a new object param `experimentInfo`.
    - added new experiment info to be displayed when the ‘View details’ button is clicked (here’s where the researchers can access the link to our website that they can post in external platforms like SONA and mTurk).

- Updates to `getAllExperiments()` API:
    - Added the experiment doc ID to the response that’s returned so we can provide the link to researchers.

- Updates to AddExperiment component:
    - Added the new fields to the object that we post to Firestore.

- Updated to Experiments page:
    - Replaced the old auth with the new auth context.
    - Fixed logic to filter ongoing vs inactive experiments.